### PR TITLE
Fix Level 6 gate position corner issue

### DIFF
--- a/script.js
+++ b/script.js
@@ -43,7 +43,7 @@ function isWall(x, y) {
         if (level === 3 && x === canvas.width - box && y === canvas.height / 2) return false;
         if (level === 4 && x === canvas.width / 2 && y === canvas.height - box) return false;
         if (level === 5 && x === canvas.width / 2 && y === 0) return false; // top center gate
-        if (level === 6 && x === canvas.width - box && y === canvas.height - box) return false; // bottom-right corner gate
+        if (level === 6 && x === canvas.width - box && y === canvas.height/2+4*box) return false;
     }
     return (
         x === 0 ||
@@ -69,7 +69,7 @@ function drawWalls() {
         else if (level === 3) ctx.fillRect(canvas.width - box, canvas.height / 2, box, box);
         else if (level === 4) ctx.fillRect(canvas.width / 2, canvas.height - box, box, box);
         else if (level === 5) ctx.fillRect(canvas.width / 2, 0, box, box);
-        else if (level === 6) ctx.fillRect(canvas.width - box, canvas.height - box, box, box);
+        else if (level === 6) ctx.fillRect(canvas.width - box, canvas.height/2 + 4 * box, box, box);
     }
 }
 
@@ -199,7 +199,7 @@ function draw() {
             (level === 3 && snakeX === canvas.width - box && snakeY === canvas.height / 2) ||
             (level === 4 && snakeX === canvas.width / 2 && snakeY === canvas.height - box) ||
             (level === 5 && snakeX === canvas.width / 2 && snakeY === 0) ||
-            (level === 6 && snakeX === canvas.width - box && snakeY === canvas.height - box)
+            (level === 6 && snakeX === canvas.width - box && snakeY === canvas.height/ 2 + 4 * box)
         ) {
             clearInterval(game);
             clearInterval(blinkInterval); // ⚡ stop blinking


### PR DESCRIPTION
Hi @Harsh-Bajpai-1194,

I have fixed the Level 6 gate positioning issue. The gate was previously spawning at the extreme corner, making it impossible to clear the level. I adjusted the y coordinate to canvas.height / 2 + 4 * box to move it towards the center, making the level playable while maintaining the game's difficulty.

Please review this fix. Happy to make any changes if requested!

Best regards,
Ankur